### PR TITLE
Handle worktrees: fix '+' marker parsing and trim merged worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: build
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+          bundler-cache: true
+
+      - name: Run specs
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "CI"
+          git config --global init.defaultBranch main
+          bundle exec rake spec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.2.0)"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Run specs
+        run: bundle exec rake spec
+
+      - name: Update version
+        run: |
+          VERSION="${{ inputs.version }}"
+          sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" lib/git-trim/version.rb
+          echo "Updated version to $VERSION"
+          cat lib/git-trim/version.rb
+
+      - name: Commit and tag
+        run: |
+          VERSION="${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add lib/git-trim/version.rb
+          git commit -m "Release v$VERSION"
+          git tag "$VERSION"
+          git push origin HEAD:${{ github.ref_name }} --tags
+
+      - name: Build gem
+        run: gem build git-trim.gemspec
+
+      - name: Push to RubyGems
+        run: |
+          mkdir -p ~/.gem
+          echo "---" > ~/.gem/credentials
+          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" >> ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push git-trim-*.gem
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          gh release create "$VERSION" \
+            --title "v$VERSION" \
+            --generate-notes \
+            git-trim-*.gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -31,33 +32,25 @@ jobs:
           echo "Updated version to $VERSION"
           cat lib/git-trim/version.rb
 
-      - name: Commit and tag
+      - name: Commit version bump
         run: |
           VERSION="${{ inputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add lib/git-trim/version.rb
           git commit -m "Release v$VERSION"
-          git tag "$VERSION"
-          git push origin HEAD:${{ github.ref_name }} --tags
 
-      - name: Build gem
-        run: gem build git-trim.gemspec
-
-      - name: Push to RubyGems
-        run: |
-          mkdir -p ~/.gem
-          echo "---" > ~/.gem/credentials
-          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" >> ~/.gem/credentials
-          chmod 0600 ~/.gem/credentials
-          gem push git-trim-*.gem
+      # Builds the gem into pkg/, tags v$VERSION, pushes the commit and
+      # tag, and publishes to RubyGems via OIDC trusted publishing.
+      - name: Release to RubyGems
+        uses: rubygems/release-gem@v1
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ inputs.version }}"
-          gh release create "$VERSION" \
+          gh release create "v$VERSION" \
             --title "v$VERSION" \
             --generate-notes \
-            git-trim-*.gem
+            pkg/git-trim-*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,35 +1,36 @@
 PATH
   remote: .
   specs:
-    git-trim (0.1.2)
+    git-trim (0.1.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.3)
-    rake (13.0.1)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    diff-lcs (1.6.2)
+    rake (13.4.2)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
 
 PLATFORMS
+  arm64-darwin-25
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (>= 1.16)
   git-trim!
   rake (~> 13.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.3
+   2.5.3

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # git trim
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/git/trim`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Deletes local branches — and the [linked worktrees](https://git-scm.com/docs/git-worktree) that hold them — once they are fully merged into `main`. Run it after a round of PRs merge and it cleans up everything that's done, while refusing to touch anything that still has work in it.
 
 ## Installation
 
@@ -22,9 +20,28 @@ Or install it yourself as:
 
 ## Usage
 
-You can call `git trim` and it will remove any branch that is fully merged into `main`, unless it is listed in the `.git-protected-branches` file. It will not remove the main branch or the branch you currently have checked out. If no local `main` exists (common in bare-repo + worktrees layouts), it compares against `origin/main` instead.
+Run `git trim` from anywhere inside a repository. It fetches (with prune), then removes every local branch that is fully merged into `main`, unless the branch is:
 
-If a merged branch is checked out in a [linked worktree](https://git-scm.com/docs/git-worktree), `git trim` removes the worktree first and then deletes the branch. Worktrees with uncommitted changes or untracked files are left alone (along with their branch).
+- `main` itself,
+- the branch you currently have checked out, or
+- listed in a `.git-protected-branches` file.
+
+If no local `main` exists (common in bare-repo + worktrees layouts), it compares against `origin/main` instead.
+
+### Worktrees
+
+If a merged branch is checked out in a linked worktree, `git trim` removes the worktree first and then deletes the branch. Worktrees with uncommitted changes or untracked files are left alone, along with their branch:
+
+```
+$ git trim
+Removed worktree /Users/you/src/project/feature-a
+Deleted branch feature-a (was fa68cf94).
+Skipping branch 'feature-b': worktree at /Users/you/src/project/feature-b has local changes
+```
+
+Commit or stash the local changes and run `git trim` again to clean up the rest.
+
+### Protected branches
 
 The `.git-protected-branches` file can reside in the current directory or any parent directory. Branch names are each listed on a line in the file. For example:
 
@@ -34,9 +51,13 @@ staging
 production
 ```
 
+## Releasing
+
+Releases are cut from the GitHub Actions **Release** workflow (Actions → Release → Run workflow → enter a version like `0.2.0`). The workflow runs the specs, bumps `lib/git-trim/version.rb`, tags `v<version>`, publishes to RubyGems via [trusted publishing](https://guides.rubygems.org/trusted-publishing/) (no API key), and creates a GitHub release.
+
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/git-trim. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/cpetersen/git-trim. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -44,4 +65,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Git::Trim project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/git-trim/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the Git::Trim project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/cpetersen/git-trim/blob/main/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Or install it yourself as:
 
 ## Usage
 
-You can call `git trim` and it will remove any branch that isn't currently merged into the current branch that isn't also in the `.git-protected-branches` file. It will not remove the main branch.
+You can call `git trim` and it will remove any branch that is fully merged into `main`, unless it is listed in the `.git-protected-branches` file. It will not remove the main branch or the branch you currently have checked out.
+
+If a merged branch is checked out in a [linked worktree](https://git-scm.com/docs/git-worktree), `git trim` removes the worktree first and then deletes the branch. Worktrees with uncommitted changes or untracked files are left alone (along with their branch).
 
 The `.git-protected-branches` file can reside in the current directory or any parent directory. Branch names are each listed on a line in the file. For example:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 ## Usage
 
-You can call `git trim` and it will remove any branch that is fully merged into `main`, unless it is listed in the `.git-protected-branches` file. It will not remove the main branch or the branch you currently have checked out.
+You can call `git trim` and it will remove any branch that is fully merged into `main`, unless it is listed in the `.git-protected-branches` file. It will not remove the main branch or the branch you currently have checked out. If no local `main` exists (common in bare-repo + worktrees layouts), it compares against `origin/main` instead.
 
 If a merged branch is checked out in a [linked worktree](https://git-scm.com/docs/git-worktree), `git trim` removes the worktree first and then deletes the branch. Worktrees with uncommitted changes or untracked files are left alone (along with their branch).
 

--- a/bin/git-trim
+++ b/bin/git-trim
@@ -2,4 +2,4 @@
 
 require 'git-trim'
 
-GitTrim.new.run(ARGV)
+exit GitTrim.new.run(ARGV)

--- a/git-trim.gemspec
+++ b/git-trim.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib", "bin"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/git-trim.gemspec
+++ b/git-trim.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{A script to remove all merged branches that aren't protected.}
   spec.description   = %q{A script to remove all merged branches that aren't specified in the .git-protected-branches file.}
-  spec.homepage      = "https://github.com/assaydepot/git-trim"
+  spec.homepage      = "https://github.com/cpetersen/git-trim"
   spec.license       = "MIT"
 
   # Specify which files should be added to the gem when it is released.

--- a/lib/git-trim.rb
+++ b/lib/git-trim.rb
@@ -11,7 +11,13 @@ class GitTrim
     protected_branches ||= []
     protected_branches << "main"
 
-    branches = %x{git branch --merged main --format='%(refname:short)'}.split("\n").collect(&:strip)
+    base = base_ref
+    unless base
+      warn "git-trim: neither 'main' nor 'origin/main' exists; nothing to trim against"
+      return 1
+    end
+
+    branches = %x{git branch --merged #{Shellwords.escape(base)} --format='%(refname:short)'}.split("\n").collect(&:strip)
     branches -= protected_branches
     branches -= [current_branch]
 
@@ -28,10 +34,21 @@ class GitTrim
       end
       puts %x{git branch -d #{Shellwords.escape(branch)}}
     end
+
+    0
   end
 
   def current_branch
     %x{git branch --show-current}.strip
+  end
+
+  # Local main when it exists; otherwise origin/main (e.g. bare-repo +
+  # worktrees layouts where no local main is checked out). Nil if neither.
+  def base_ref
+    ["main", "origin/main"].find do |ref|
+      %x{git rev-parse --verify --quiet #{Shellwords.escape(ref)}}
+      $?.success?
+    end
   end
 
   # Maps branch name => worktree path for linked worktrees. The first entry

--- a/lib/git-trim.rb
+++ b/lib/git-trim.rb
@@ -25,9 +25,14 @@ class GitTrim
 
     branches.each do |branch|
       if (path = worktrees[branch])
-        %x{git worktree remove #{Shellwords.escape(path)}}
+        output = %x{git worktree remove #{Shellwords.escape(path)} 2>&1}
         unless $?.success?
-          puts "Skipping branch '#{branch}': could not remove worktree at #{path}"
+          if output.include?("contains modified or untracked files")
+            puts "Skipping branch '#{branch}': worktree at #{path} has local changes"
+          else
+            puts "Skipping branch '#{branch}': could not remove worktree at #{path}"
+            puts output
+          end
           next
         end
         puts "Removed worktree #{path}"

--- a/lib/git-trim.rb
+++ b/lib/git-trim.rb
@@ -1,4 +1,5 @@
 require "git-trim/version"
+require "shellwords"
 
 class GitTrim
   def run(argv=nil)
@@ -10,11 +11,37 @@ class GitTrim
     protected_branches ||= []
     protected_branches << "main"
 
-    branches = %x{git branch --merged main}.split("\n").collect {|b| b.gsub('*', '').strip}
+    branches = %x{git branch --merged main --format='%(refname:short)'}.split("\n").collect(&:strip)
     branches -= protected_branches
+    branches -= [current_branch]
+
+    worktrees = linked_worktrees
 
     branches.each do |branch|
-      puts %x{git branch -d #{branch}}
+      if (path = worktrees[branch])
+        %x{git worktree remove #{Shellwords.escape(path)}}
+        unless $?.success?
+          puts "Skipping branch '#{branch}': could not remove worktree at #{path}"
+          next
+        end
+        puts "Removed worktree #{path}"
+      end
+      puts %x{git branch -d #{Shellwords.escape(branch)}}
+    end
+  end
+
+  def current_branch
+    %x{git branch --show-current}.strip
+  end
+
+  # Maps branch name => worktree path for linked worktrees. The first entry
+  # in `git worktree list` is the main worktree, which is never removable.
+  def linked_worktrees
+    entries = %x{git worktree list --porcelain}.split("\n\n")
+    entries.drop(1).each_with_object({}) do |entry, map|
+      path = entry[/^worktree (.+)$/, 1]
+      branch = entry[/^branch refs\/heads\/(.+)$/, 1]
+      map[branch] = path if path && branch
     end
   end
 

--- a/spec/git-trim_spec.rb
+++ b/spec/git-trim_spec.rb
@@ -1,9 +1,122 @@
+require "tmpdir"
+require "stringio"
+
 RSpec.describe GitTrim do
   it "has a version number" do
     expect(GitTrim::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe "#run" do
+    around do |example|
+      Dir.mktmpdir do |tmp|
+        @tmp = File.realpath(tmp)
+        example.run
+      end
+    end
+
+    let(:origin) { File.join(@tmp, "origin") }
+    let(:repo) { File.join(@tmp, "repo") }
+
+    def git(dir, *args)
+      system("git", "-C", dir, *args, out: File::NULL, err: File::NULL) or
+        raise "git #{args.join(' ')} failed in #{dir}"
+    end
+
+    def run_trim
+      Dir.chdir(repo) do
+        original_stdout = $stdout
+        $stdout = StringIO.new
+        begin
+          GitTrim.new.run
+        ensure
+          $stdout = original_stdout
+        end
+      end
+    end
+
+    def branches
+      %x{git -C #{repo} branch --format='%(refname:short)'}.split("\n")
+    end
+
+    def worktree_paths
+      %x{git -C #{repo} worktree list --porcelain}.scan(/^worktree (.+)$/).flatten
+    end
+
+    before do
+      git(@tmp, "init", "-b", "main", origin)
+      git(origin, "config", "user.email", "test@example.com")
+      git(origin, "config", "user.name", "Test")
+      git(origin, "commit", "--allow-empty", "-m", "initial")
+      git(@tmp, "clone", origin, repo)
+      git(repo, "config", "user.email", "test@example.com")
+      git(repo, "config", "user.name", "Test")
+    end
+
+    it "deletes branches that are merged into main" do
+      git(repo, "branch", "merged-branch")
+      run_trim
+      expect(branches).not_to include("merged-branch")
+    end
+
+    it "keeps branches that are not merged into main" do
+      git(repo, "checkout", "-b", "unmerged-branch")
+      git(repo, "commit", "--allow-empty", "-m", "unmerged work")
+      git(repo, "checkout", "main")
+      run_trim
+      expect(branches).to include("unmerged-branch")
+    end
+
+    it "keeps main" do
+      run_trim
+      expect(branches).to include("main")
+    end
+
+    it "keeps main even when it is checked out in a worktree" do
+      git(repo, "checkout", "-b", "feature")
+      git(repo, "worktree", "add", File.join(@tmp, "wt-main"), "main")
+      run_trim
+      expect(branches).to include("main")
+    end
+
+    it "keeps the current branch even when merged" do
+      git(repo, "checkout", "-b", "current-merged")
+      run_trim
+      expect(branches).to include("current-merged")
+    end
+
+    it "keeps branches listed in .git-protected-branches" do
+      git(repo, "branch", "staging")
+      File.write(File.join(repo, ".git-protected-branches"), "staging\n")
+      run_trim
+      expect(branches).to include("staging")
+    end
+
+    it "removes worktrees whose branch is merged, then deletes the branch" do
+      wt = File.join(@tmp, "wt-merged")
+      git(repo, "worktree", "add", "-b", "merged-wt-branch", wt, "main")
+      run_trim
+      expect(branches).not_to include("merged-wt-branch")
+      expect(worktree_paths).not_to include(wt)
+      expect(File).not_to exist(wt)
+    end
+
+    it "keeps worktrees whose branch is not merged" do
+      wt = File.join(@tmp, "wt-unmerged")
+      git(repo, "worktree", "add", "-b", "unmerged-wt-branch", wt, "main")
+      git(wt, "commit", "--allow-empty", "-m", "unmerged work")
+      run_trim
+      expect(branches).to include("unmerged-wt-branch")
+      expect(worktree_paths).to include(wt)
+    end
+
+    it "skips dirty worktrees and keeps their branch" do
+      wt = File.join(@tmp, "wt-dirty")
+      git(repo, "worktree", "add", "-b", "dirty-wt-branch", wt, "main")
+      File.write(File.join(wt, "untracked.txt"), "uncommitted")
+      run_trim
+      expect(branches).to include("dirty-wt-branch")
+      expect(worktree_paths).to include(wt)
+      expect(File).to exist(File.join(wt, "untracked.txt"))
+    end
   end
 end

--- a/spec/git-trim_spec.rb
+++ b/spec/git-trim_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe GitTrim do
         original_stdout = $stdout
         $stdout = StringIO.new
         begin
-          GitTrim.new.run
+          status = GitTrim.new.run
+          { status: status, stdout: $stdout.string }
         ensure
           $stdout = original_stdout
         end
@@ -122,19 +123,21 @@ RSpec.describe GitTrim do
       git(repo, "checkout", "-b", "feature")
       git(repo, "branch", "-D", "main")
       git(repo, "remote", "remove", "origin")
-      status = nil
-      expect { status = run_trim }.to output(/neither 'main' nor 'origin\/main' exists/).to_stderr
-      expect(status).to eq(1)
+      result = nil
+      expect { result = run_trim }.to output(/neither 'main' nor 'origin\/main' exists/).to_stderr
+      expect(result[:status]).to eq(1)
     end
 
     it "skips dirty worktrees and keeps their branch" do
       wt = File.join(@tmp, "wt-dirty")
       git(repo, "worktree", "add", "-b", "dirty-wt-branch", wt, "main")
       File.write(File.join(wt, "untracked.txt"), "uncommitted")
-      run_trim
+      result = run_trim
       expect(branches).to include("dirty-wt-branch")
       expect(worktree_paths).to include(wt)
       expect(File).to exist(File.join(wt, "untracked.txt"))
+      expect(result[:stdout]).to include("Skipping branch 'dirty-wt-branch': worktree at #{wt} has local changes")
+      expect(result[:stdout]).not_to include("fatal")
     end
   end
 end

--- a/spec/git-trim_spec.rb
+++ b/spec/git-trim_spec.rb
@@ -109,6 +109,24 @@ RSpec.describe GitTrim do
       expect(worktree_paths).to include(wt)
     end
 
+    it "falls back to origin/main when no local main exists" do
+      git(repo, "checkout", "-b", "feature")
+      git(repo, "branch", "-D", "main")
+      git(repo, "branch", "merged-branch", "origin/main")
+      run_trim
+      expect(branches).not_to include("merged-branch")
+      expect(branches).to include("feature")
+    end
+
+    it "warns and returns 1 when neither main nor origin/main exists" do
+      git(repo, "checkout", "-b", "feature")
+      git(repo, "branch", "-D", "main")
+      git(repo, "remote", "remove", "origin")
+      status = nil
+      expect { status = run_trim }.to output(/neither 'main' nor 'origin\/main' exists/).to_stderr
+      expect(status).to eq(1)
+    end
+
     it "skips dirty worktrees and keeps their branch" do
       wt = File.join(@tmp, "wt-dirty")
       git(repo, "worktree", "add", "-b", "dirty-wt-branch", wt, "main")


### PR DESCRIPTION
## Problem

Running `git trim` in a repo with linked worktrees produced a cascade of errors:

```
error: branch '+' not found
error: cannot delete branch 'perf/factory-build-not-create' used by worktree at '...'
```

`git branch --merged` prefixes branches checked out in worktrees with `+ ` (the same way it marks the current branch with `* `). The parser only stripped `*`, so a worktree branch became the literal string `+ perf/foo`, and `git branch -d + perf/foo` was parsed by git as two branch arguments.

Worse: a `main` checked out in a worktree showed up as `+ main`, which didn't match `main` in the protected list — so the bug could **delete your local main**.

## Fix

- Parse branches with `--format='%(refname:short)'` so the `*`/`+` markers never appear
- Explicitly skip the current branch
- New feature: when a merged branch is checked out in a linked worktree, remove the worktree first, then delete the branch
- Dirty worktrees (uncommitted/untracked changes) are skipped and their branch kept — `git worktree remove` refuses by design and we honor that
- Shell-escape branch names and worktree paths

## Tests

Replaced the placeholder spec with 10 integration specs that build real temp git repos (origin + clone + worktrees) and assert on resulting branches/worktrees. Also loosened the `bundler ~> 1.16` dev-dependency pin and regenerated the lockfile so the suite runs on modern Ruby (bundler 1.17 crashes on Ruby 3.3 due to removed `untaint`).

All 10 specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)