### PR TITLE
Add CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: build
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+          bundler-cache: true
+
+      - name: Run specs
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "CI"
+          git config --global init.defaultBranch main
+          bundle exec rake spec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.2.0)"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Run specs
+        run: bundle exec rake spec
+
+      - name: Update version
+        run: |
+          VERSION="${{ inputs.version }}"
+          sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" lib/git-trim/version.rb
+          echo "Updated version to $VERSION"
+          cat lib/git-trim/version.rb
+
+      - name: Commit and tag
+        run: |
+          VERSION="${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add lib/git-trim/version.rb
+          git commit -m "Release v$VERSION"
+          git tag "$VERSION"
+          git push origin HEAD:${{ github.ref_name }} --tags
+
+      - name: Build gem
+        run: gem build git-trim.gemspec
+
+      - name: Push to RubyGems
+        run: |
+          mkdir -p ~/.gem
+          echo "---" > ~/.gem/credentials
+          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" >> ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push git-trim-*.gem
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          gh release create "$VERSION" \
+            --title "v$VERSION" \
+            --generate-notes \
+            git-trim-*.gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -31,33 +32,25 @@ jobs:
           echo "Updated version to $VERSION"
           cat lib/git-trim/version.rb
 
-      - name: Commit and tag
+      - name: Commit version bump
         run: |
           VERSION="${{ inputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add lib/git-trim/version.rb
           git commit -m "Release v$VERSION"
-          git tag "$VERSION"
-          git push origin HEAD:${{ github.ref_name }} --tags
 
-      - name: Build gem
-        run: gem build git-trim.gemspec
-
-      - name: Push to RubyGems
-        run: |
-          mkdir -p ~/.gem
-          echo "---" > ~/.gem/credentials
-          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" >> ~/.gem/credentials
-          chmod 0600 ~/.gem/credentials
-          gem push git-trim-*.gem
+      # Builds the gem into pkg/, tags v$VERSION, pushes the commit and
+      # tag, and publishes to RubyGems via OIDC trusted publishing.
+      - name: Release to RubyGems
+        uses: rubygems/release-gem@v1
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ inputs.version }}"
-          gh release create "$VERSION" \
+          gh release create "v$VERSION" \
             --title "v$VERSION" \
             --generate-notes \
-            git-trim-*.gem
+            pkg/git-trim-*.gem

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # git trim
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/git/trim`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Deletes local branches — and the [linked worktrees](https://git-scm.com/docs/git-worktree) that hold them — once they are fully merged into `main`. Run it after a round of PRs merge and it cleans up everything that's done, while refusing to touch anything that still has work in it.
 
 ## Installation
 
@@ -22,9 +20,28 @@ Or install it yourself as:
 
 ## Usage
 
-You can call `git trim` and it will remove any branch that is fully merged into `main`, unless it is listed in the `.git-protected-branches` file. It will not remove the main branch or the branch you currently have checked out. If no local `main` exists (common in bare-repo + worktrees layouts), it compares against `origin/main` instead.
+Run `git trim` from anywhere inside a repository. It fetches (with prune), then removes every local branch that is fully merged into `main`, unless the branch is:
 
-If a merged branch is checked out in a [linked worktree](https://git-scm.com/docs/git-worktree), `git trim` removes the worktree first and then deletes the branch. Worktrees with uncommitted changes or untracked files are left alone (along with their branch).
+- `main` itself,
+- the branch you currently have checked out, or
+- listed in a `.git-protected-branches` file.
+
+If no local `main` exists (common in bare-repo + worktrees layouts), it compares against `origin/main` instead.
+
+### Worktrees
+
+If a merged branch is checked out in a linked worktree, `git trim` removes the worktree first and then deletes the branch. Worktrees with uncommitted changes or untracked files are left alone, along with their branch:
+
+```
+$ git trim
+Removed worktree /Users/you/src/project/feature-a
+Deleted branch feature-a (was fa68cf94).
+Skipping branch 'feature-b': worktree at /Users/you/src/project/feature-b has local changes
+```
+
+Commit or stash the local changes and run `git trim` again to clean up the rest.
+
+### Protected branches
 
 The `.git-protected-branches` file can reside in the current directory or any parent directory. Branch names are each listed on a line in the file. For example:
 
@@ -34,9 +51,13 @@ staging
 production
 ```
 
+## Releasing
+
+Releases are cut from the GitHub Actions **Release** workflow (Actions → Release → Run workflow → enter a version like `0.2.0`). The workflow runs the specs, bumps `lib/git-trim/version.rb`, tags `v<version>`, publishes to RubyGems via [trusted publishing](https://guides.rubygems.org/trusted-publishing/) (no API key), and creates a GitHub release.
+
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/git-trim. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/cpetersen/git-trim. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -44,4 +65,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Git::Trim project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/git-trim/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the Git::Trim project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/cpetersen/git-trim/blob/main/CODE_OF_CONDUCT.md).

--- a/git-trim.gemspec
+++ b/git-trim.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{A script to remove all merged branches that aren't protected.}
   spec.description   = %q{A script to remove all merged branches that aren't specified in the .git-protected-branches file.}
-  spec.homepage      = "https://github.com/assaydepot/git-trim"
+  spec.homepage      = "https://github.com/cpetersen/git-trim"
   spec.license       = "MIT"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
Adds GitHub Actions for CI and releasing, modeled on the scientist-labs gems but using **RubyGems trusted publishing** (OIDC) instead of an API-key secret:

- **ci.yml** — runs the spec suite on every pull request
- **release.yml** — manual `workflow_dispatch` with a version input: runs specs, bumps `lib/git-trim/version.rb`, commits, then `rubygems/release-gem@v1` runs `rake release` (builds to `pkg/`, tags `v<version>`, pushes commit + tag, publishes to RubyGems via OIDC), and finally creates a GitHub release with generated notes and the built gem attached.

No `RUBYGEMS_API_KEY` secret is needed — authentication is via GitHub's OIDC token, with sigstore attestations enabled by default.

Stacked on #5 because the release workflow runs the specs, which only pass on that branch (main still has the placeholder failing spec and a bundler-1.17 lockfile that won't install on modern Ruby). Merge #5 first; GitHub will retarget this PR to main automatically.

**One-time setup before first release:** register the trusted publisher on rubygems.org — https://rubygems.org/gems/git-trim → Trusted publishers → Create:
- Publisher: GitHub Actions
- Repository owner: `cpetersen`, repository: `git-trim`
- Workflow filename: `release.yml`
- Environment: leave blank

Note: releases are now tagged `v0.2.0` style (Bundler's convention) rather than the bare `0.2.0` tags the scientist-labs workflows create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)