### PR TITLE
Fix release workflow: re-lock Gemfile.lock after version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,21 @@ jobs:
           echo "Updated version to $VERSION"
           cat lib/git-trim/version.rb
 
+      # bundler-cache sets frozen/deployment mode, which rejects the now
+      # out-of-date lockfile entry for git-trim itself. Re-lock so the
+      # release commit keeps the gemspec and lockfile in sync.
+      - name: Update Gemfile.lock
+        run: |
+          bundle config unset deployment
+          bundle config unset frozen
+          BUNDLE_FROZEN=false BUNDLE_DEPLOYMENT=false bundle lock
+
       - name: Commit version bump
         run: |
           VERSION="${{ inputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add lib/git-trim/version.rb
+          git add lib/git-trim/version.rb Gemfile.lock
           git commit -m "Release v$VERSION"
 
       # Builds the gem into pkg/, tags v$VERSION, pushes the commit and


### PR DESCRIPTION
The first release run failed at `rake release`:

> The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set

`ruby/setup-ruby` with `bundler-cache: true` enables frozen/deployment mode, and the workflow's version bump makes git-trim's own path-gem entry in `Gemfile.lock` stale — so `bundle exec rake release` refuses to start. (The scientist-labs workflows don't hit this because they use plain `gem build`/`gem push` without `bundle exec`.)

Fix: after bumping `version.rb`, unset frozen/deployment and run `bundle lock`, then include `Gemfile.lock` in the release commit so gemspec and lockfile stay in sync.

The failed run pushed nothing (no tag, no commit — it died before `rake release` did any git operations), so rerunning after this merges is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)